### PR TITLE
Add compatibility code for tensorflow 2.0

### DIFF
--- a/models.py
+++ b/models.py
@@ -5,7 +5,11 @@ from config import imshape, n_classes, model_name
 from tensorflow.keras import backend as K
 from tensorflow.keras.optimizers import Adam
 import numpy as np
-import tensorflow as tf
+#import tensorflow as tf
+#Compatibility code for tensorflow 2
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 import os
 
 

--- a/tensorboard_callbacks.py
+++ b/tensorboard_callbacks.py
@@ -1,6 +1,10 @@
 from PIL import Image
 import io
-import tensorflow as tf
+#import tensorflow as tf
+#Compatibility code for tensorflow 2
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 import os
 import cv2
 import numpy as np


### PR DESCRIPTION
Colab and many people have moved to Tensorflow 2.0 environments, so I have added some compatibility code to run on TF2.
I have tested on Colab, tensorflow 2.3

The changes are quite simple, and they follow Google guidance:
Change all:
import tensorflow as tf
To:
import tensorflow.compat.v1 as tf
tf.disable_v2_behavior()